### PR TITLE
Added objectWithoutNulls function

### DIFF
--- a/src/HaskellWorks/Data/Aeson.hs
+++ b/src/HaskellWorks/Data/Aeson.hs
@@ -1,33 +1,10 @@
 module HaskellWorks.Data.Aeson
-    ( (.=?)
-    , (.=!)
-    , OptionalPairs(..)
-    , objectWith
-    , objectWithoutNulls
+    ( objectWithoutNulls
     ) where
 
 import Data.Aeson
 import Data.Aeson.Types
-import Data.Semigroup
 import Data.Text
-
-(.=?) :: ToJSON v => Text -> Maybe v -> OptionalPairs
-(.=?) a (Just b) = OptionalPairs ((a .= b):)
-(.=?) _ Nothing  = OptionalPairs id
-
-(.=!) :: ToJSON v => Text -> v -> OptionalPairs
-(.=!) a b = OptionalPairs ((a .= b):)
-
-newtype OptionalPairs = OptionalPairs ([Pair] -> [Pair])
-
-instance Semigroup OptionalPairs
-
-instance Monoid OptionalPairs where
-  mappend (OptionalPairs f) (OptionalPairs g) = OptionalPairs (f . g)
-  mempty = OptionalPairs id
-
-objectWith :: OptionalPairs -> Value
-objectWith (OptionalPairs f) = object (f [])
 
 objectWithoutNulls :: [Pair] -> Value
 objectWithoutNulls = object . Prelude.filter (not . isNull . snd)

--- a/src/HaskellWorks/Data/Aeson.hs
+++ b/src/HaskellWorks/Data/Aeson.hs
@@ -3,6 +3,7 @@ module HaskellWorks.Data.Aeson
     , (.=!)
     , OptionalPairs(..)
     , objectWith
+    , objectWithoutNulls
     ) where
 
 import Data.Aeson
@@ -27,3 +28,9 @@ instance Monoid OptionalPairs where
 
 objectWith :: OptionalPairs -> Value
 objectWith (OptionalPairs f) = object (f [])
+
+objectWithoutNulls :: [Pair] -> Value
+objectWithoutNulls = object . Prelude.filter (not . isNull . snd)
+  where
+    isNull Null = True
+    isNull _    = False

--- a/test/HaskellWorks/Data/AesonSpec.hs
+++ b/test/HaskellWorks/Data/AesonSpec.hs
@@ -24,3 +24,14 @@ spec = describe "HaskellWorks.Data.Aeson" $ do
           , "two"    .= (2 :: Int)
           ]
     actual `shouldBe` expected
+  it "objectWithoutNulls should stould strip nulls" $ do
+    let actual = objectWithoutNulls
+          [ "one"    .= (1 :: Int)
+          , "two"    .= Just (2 :: Int)
+          , "three"  .= (Nothing :: Maybe Int)
+          ]
+    let expected = object
+          [ "one"    .= (1 :: Int)
+          , "two"    .= (2 :: Int)
+          ]
+    actual `shouldBe` expected

--- a/test/HaskellWorks/Data/AesonSpec.hs
+++ b/test/HaskellWorks/Data/AesonSpec.hs
@@ -13,17 +13,6 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "HaskellWorks.Data.Aeson" $ do
-  it "123123" $ do
-    let actual = objectWith
-          (  "one"    .=! (1 :: Int)
-          <> "two"    .=? Just (2 :: Int)
-          <> "three"  .=? (Nothing :: Maybe Int)
-          )
-    let expected = object
-          [ "one"    .= (1 :: Int)
-          , "two"    .= (2 :: Int)
-          ]
-    actual `shouldBe` expected
   it "objectWithoutNulls should stould strip nulls" $ do
     let actual = objectWithoutNulls
           [ "one"    .= (1 :: Int)


### PR DESCRIPTION
Added function similar to `object`, which takes a list of pairs and returns a JSON value, except all the `null` values at the top level will be stripped out (i.e. undefined).