### PR TITLE
Test newer GHC versions up to 9.14.1 and widen dependency bounds

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.8.1", "9.6.3", "9.4.8", "9.2.8", "9.0.2", "8.10.7"]
+        ghc: ["9.14.1", "9.12.4", "9.10.3", "9.8.4", "9.6.7", "9.4.8"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
         exclude:
         - os: windows-latest

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -20,8 +20,14 @@ jobs:
         ghc: ["9.14.1", "9.12.4", "9.10.3", "9.8.4", "9.6.7", "9.4.8"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
         exclude:
+        # GHC 9.14.1 on Windows: ghc-paths' custom Setup is incompatible with
+        # the bundled Cabal 3.16, so the doctest dependency cannot be solved.
         - os: windows-latest
-          ghc: "9.4.2"
+          ghc: "9.14.1"
+        # GHC 9.4.8 on Windows: doctest cannot locate the chocolatey-installed
+        # ghc.exe, so the doctest suite fails to run.
+        - os: windows-latest
+          ghc: "9.4.8"
 
     env:
       # Modify this value to "invalidate" the cabal cache.

--- a/hw-aeson.cabal
+++ b/hw-aeson.cabal
@@ -12,7 +12,7 @@ maintainer:             newhoggy@gmail.com
 copyright:              2018-2022 John Ky
 license:                BSD-3-Clause
 license-file:           LICENSE
-tested-with:            GHC == 9.4.4, GHC == 9.2.5, GHC == 9.0.2, GHC == 8.10.7, GHC == 8.8.4, GHC == 8.6.5
+tested-with:            GHC == 9.14.1, GHC == 9.12.4, GHC == 9.10.3, GHC == 9.8.4, GHC == 9.6.7, GHC == 9.4.8, GHC == 9.2.8, GHC == 9.0.2, GHC == 8.10.7, GHC == 8.8.4
 build-type:             Simple
 extra-source-files:     README.md
 
@@ -22,13 +22,13 @@ source-repository head
 
 common base                       { build-depends: base                       >= 4.11       && < 5      }
 
-common aeson                      { build-depends: aeson                      >= 1.4        && < 2.3    }
+common aeson                      { build-depends: aeson                      >= 1.4        && < 2.4    }
 common bytestring                 { build-depends: bytestring                 >= 0.10       && < 0.13   }
-common containers                 { build-depends: containers                 >= 0.6        && < 0.8    }
-common doctest                    { build-depends: doctest                    >= 0.16.2     && < 0.23   }
+common containers                 { build-depends: containers                 >= 0.6        && < 0.9    }
+common doctest                    { build-depends: doctest                    >= 0.16.2     && < 0.26   }
 common doctest-discover           { build-depends: doctest-discover           >= 0.2        && < 0.3    }
-common hashable                   { build-depends: hashable                   >= 1.3        && < 1.5    }
-common hedgehog                   { build-depends: hedgehog                   >= 0.6        && < 1.5    }
+common hashable                   { build-depends: hashable                   >= 1.3        && < 1.6    }
+common hedgehog                   { build-depends: hedgehog                   >= 0.6        && < 1.8    }
 common hspec                      { build-depends: hspec                      >= 2.4        && < 3      }
 common text                       { build-depends: text                       >= 1.2        && < 3      }
 common text-short                 { build-depends: text-short                 >= 0.1.3      && < 0.2    }

--- a/src/HaskellWorks/Data/Aeson/Compat/Map/V1.hs
+++ b/src/HaskellWorks/Data/Aeson/Compat/Map/V1.hs
@@ -57,7 +57,7 @@ import Data.Hashable (Hashable)
 import Data.HashMap.Strict (HashMap)
 import Data.Map (Map)
 import Data.Text (Text)
-import Prelude hiding (filter, foldl, foldr, lookup, map, null)
+import Prelude hiding (filter, foldl, foldl', foldr, lookup, map, null)
 
 type KeyMap v = HM.HashMap Text v
 type Key = Text

--- a/src/HaskellWorks/Data/Aeson/Compat/Map/V2.hs
+++ b/src/HaskellWorks/Data/Aeson/Compat/Map/V2.hs
@@ -63,7 +63,7 @@ import qualified HaskellWorks.Data.Aeson.Compat as J
 import Data.HashMap.Strict (HashMap)
 import Data.Map (Map)
 import Data.Text (Text)
-import Prelude hiding (filter, foldl, foldr, lookup, map, null)
+import Prelude hiding (filter, foldl, foldl', foldr, lookup, map, null)
 
 type KeyMap v = KM.KeyMap v
 type Key = J.Key


### PR DESCRIPTION
Brings tested GHC versions in line with hw-prim.

## GHC versions

- `tested-with`: GHC 9.14.1, 9.12.4, 9.10.3, 9.8.4, 9.6.7, 9.4.8, 9.2.8, 9.0.2, 8.10.7, 8.8.4
- CI matrix: `["9.14.1", "9.12.4", "9.10.3", "9.8.4", "9.6.7", "9.4.8"]`

## Dependency bound changes

| Dependency | Old upper bound | New upper bound |
|------------|-----------------|-----------------|
| aeson      | < 2.3           | < 2.4           |
| containers | < 0.8           | < 0.9           |
| doctest    | < 0.23          | < 0.26          |
| hashable   | < 1.5           | < 1.6           |
| hedgehog   | < 1.5           | < 1.8           |

These widenings admit the dependency versions required for GHC up to 9.14.1 (base-4.22).

Verified locally with GHC 9.8.4: `cabal build --enable-tests` succeeds and both test suites pass, with the solver picking the newly admitted versions (aeson 2.3.0.0, doctest 0.25.0, hashable 1.5.1.0, hedgehog 1.7).